### PR TITLE
Added store code to app settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -172,11 +172,10 @@
       // First, lets make sure there is no trailing slash, we'll add one later.
       if (url.slice(-1) === '/') { url = url.slice(0, -1); }
       // Test whether we have a front-controller reference here.
-      if (url.indexOf('index.php') === -1)
-      {
-        return url+'/index.php';
-      }
-      return url;
+      if (url.indexOf('index.php') === -1) { url=url+'/index.php'; }
+      // Add the store code if present
+      if (this.settings.store_code) { url=url+"/"+this.settings.store_code; }
+      return url;    
     },
 
     // Format the line breaks for web

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,11 @@
       "name": "order_id_field_id",
       "type": "number",
       "required": false
-    }
+    },
+    {
+     "name": "store_code",
+     "type": "text",
+     "required": false   
+    }    
   ]
 }


### PR DESCRIPTION
For Magento installations that have the setting "Add store code to URLS" turned-on, the app will make a call to an incorrect URL. This change will allow customers to set the store code in the app as a setting, instead of changing the relevant lines in the code. 

Translations need a bit of work :)

For reference:
https://support.zendesk.com/agent/tickets/1026929