### PR TITLE
Mark hidden strings

### DIFF
--- a/translations/en.yml
+++ b/translations/en.yml
@@ -14,6 +14,7 @@ parts:
       key: "txt.apps.magento.app.name"
       title: "App name"
       value: "Magento"
+      hidden: true
   - translation:
       key: "txt.apps.magento.app.parameters.url.label"
       title: "Label for the Magento Store URL"


### PR DESCRIPTION
Administrative task: Adding ```hidden: true``` to the strings that translators do not to translate.

cc: @pdeuter, @zendesk/quokka

risk: very low (just string change)