### PR TITLE
[MI-644] Localize magento order statuses

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,6 +100,7 @@
 
       // Got the profile data, populate interface
       this.profileData.created = this.localizeDate(this.profileData.created);
+      this.profileData.recentOrders = this._localizeStatuses(this.profileData.recentOrders);
       this.switchTo('profile', this.profileData);
 
       this._appendTicketOrder();
@@ -226,6 +227,14 @@
       }
 
       this.$('.order').html(orderTemplate);
+    },
+
+    _localizeStatuses: function(orders) {
+      orders.forEach(function(order, key) {
+        orders[key].status = this.I18n.t('order.statuses.' + order.status);
+      }, this);
+
+      return orders;
     }
 
   };

--- a/app.js
+++ b/app.js
@@ -231,7 +231,8 @@
 
     _localizeStatuses: function(orders) {
       orders.forEach(function(order, key) {
-        orders[key].status = this.I18n.t('order.statuses.' + order.status);
+        var localizedStatus = this.I18n.t('order.statuses.' + order.status);
+        orders[key].status = localizedStatus.indexOf('Missing translation') == 0 ? order.status : localizedStatus;
       }, this);
 
       return orders;

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -53,6 +53,20 @@
     "error": {
       "message": "Order does not exist",
       "no_address": "No address."
+    },
+    "statuses": {
+      "pending": "Pending",
+      "processing": "Processing",
+      "pending_payment": "Pending Payment",
+      "payment_review": "Payment Review",
+      "suspected_fraud": "Suspected Fraud",
+      "holded": "On Hold",
+      "complete": "Complete",
+      "closed": "Closed",
+      "canceled": "Canceled",
+      "paypal_reversed": "Paypal Reversed",
+      "paypal_canceled_reversal": "Paypal Canceled Reversal",
+      "pending_paypal": "Pending Paypal"
     }
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -17,12 +17,12 @@
       },
       "store_code": {
         "label": {
-          "title": "Label for the Magento Store Code",
+          "title": "Label for the Magento Store Code. See for example: https://support.google.com/business/answer/4542487?hl=en",
           "value": "Store Code"
         },
-        "helpText": {
+        "help_text": {
           "title": "Helper text for the Magento Store Code",
-          "value": "Add the default store code you use, if you have 'Add Store Code to Urls' set to 'Yes' on your Magento store"
+          "value": "Add the default store code you use, if you have 'Add Store Code to Urls' set to 'Yes' on your Magento store."
         }
       },
       "access_token": {
@@ -149,6 +149,56 @@
       "no_address": {
         "title": "No address is present for that user",
         "value": "No address."
+      }
+    },
+    "statuses": {
+      "pending": {
+        "title": "Pending orders are brand new orders that have not been processed.",
+        "value": "Pending"
+      },
+      "processing": {
+        "title": "Processing orders are orders that have been assigned an invoice.",
+        "value": "Processing"
+      },
+      "pending_payment": {
+        "title": "Pending Payment orders are brand new orders that have not been cleared by a payment gateway.",
+        "value": "Pending Payment"
+      },
+      "payment_review": {
+        "title": "Payment Review means that the order is currently under review on the payment gateway.",
+        "value": "Payment Review"
+      },
+      "suspected_fraud": {
+        "title": "Suspected Fraud means that the order has been flagged by Magento as possible fraud.",
+        "value": "Suspected Fraud"
+      },
+      "holded": {
+        "title": "On Hold means no further action can be done on the order until it is taken off hold.",
+        "value": "On Hold"
+      },
+      "complete": {
+        "title": "Orders marked as complete have been invoiced and have shipped.",
+        "value": "Complete"
+      },
+      "closed": {
+        "title": "Closed orders are orders that have had a credit memo assigned to it and the customer has been refunded.",
+        "value": "Closed"
+      },
+      "canceled": {
+        "title": "Cancelled orders are for orders that have been cancelled such as if the order has not been paid for.",
+        "value": "Canceled"
+      },
+      "paypal_reversed": {
+        "title": "Status specific for Paypal processed orders which has been reversed and refunded.",
+        "value": "Paypal Reversed"
+      },
+      "paypal_canceled_reversal": {
+        "title": "Status specific for Paypal processed orders which has been reversed but subsequently reprocessed.",
+        "value": "Paypal Cancel Reversal"
+      },
+      "pending_paypal": {
+        "title": "Status specific for Paypal processed orders which has been set to pending on Paypal's System.",
+        "value": "Pending Paypal"
       }
     }
   }

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -135,3 +135,51 @@ parts:
       key: "txt.apps.magento.order.error.no_address"
       title: "No address is present for that user"
       value: "No address."
+  - translation:
+      key: "txt.apps.magento.order.statuses.pending"
+      title: "Pending orders are brand new orders that have not been processed."
+      value: "Pending"
+  - translation:
+      key: "txt.apps.magento.order.statuses.processing"
+      title: "Processing orders are orders that have been assigned an invoice."
+      value: "Processing"
+  - translation:
+      key: "txt.apps.magento.order.statuses.pending_payment"
+      title: "Pending Payment orders are brand new orders that have not been cleared by a payment gateway."
+      value: "Pending Payment"
+  - translation:
+      key: "txt.apps.magento.order.statuses.payment_review"
+      title: "Payment Review means that the order is currently under review on the payment gateway."
+      value: "Payment Review"
+  - translation:
+      key: "txt.apps.magento.order.statuses.suspected_fraud"
+      title: "Suspected Fraud means that the order has been flagged by Magento as possible fraud."
+      value: "Suspected Fraud"
+  - translation:
+      key: "txt.apps.magento.order.statuses.holded"
+      title: "On Hold means no further action can be done on the order until it is taken off hold."
+      value: "On Hold"
+  - translation:
+      key: "txt.apps.magento.order.statuses.complete"
+      title: "Orders marked as complete have been invoiced and have shipped."
+      value: "Complete"
+  - translation:
+      key: "txt.apps.magento.order.statuses.closed"
+      title: "Closed orders are orders that have had a credit memo assigned to it and the customer has been refunded."
+      value: "Closed"
+  - translation:
+      key: "txt.apps.magento.order.statuses.canceled"
+      title: "Cancelled orders are for orders that have been cancelled such as if the order has not been paid for."
+      value: "Canceled"
+  - translation:
+      key: "txt.apps.magento.order.statuses.paypal_reversed"
+      title: "Status specific for Paypal processed orders which has been reversed and refunded."
+      value: "Paypal Reversed"
+  - translation:
+      key: "txt.apps.magento.order.statuses.paypal_canceled_reversal"
+      title: "Status specific for Paypal processed orders which has been reversed but subsequently reprocessed."
+      value: "Paypal Cancel Reversal"
+  - translation:
+      key: "txt.apps.magento.order.statuses.pending_paypal"
+      title: "Status specific for Paypal processed orders which has been set to pending on Paypal's System."
+      value: "Pending Paypal"


### PR DESCRIPTION
/cc @zendesk/mintegrations @zendesk/i18n 

### Description

Localize Magento order statuses. 

Defaults back to the status string if there is no available translation as Magento allows creation of custom order statuses.

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-644

### Risks
* [low] Order status may appear as missing translations.