### PR TITLE
[MI-644] Localize order status in the order template.

### DIFF
--- a/app.js
+++ b/app.js
@@ -101,6 +101,7 @@
       // Got the profile data, populate interface
       this.profileData.created = this.localizeDate(this.profileData.created);
       this.profileData.recentOrders.forEach(function(order, key) {
+        this.profileData.recentOrders[key].classname = order.status;
         this.profileData.recentOrders[key].status = this._localizeStatus(order.status);
       }, this);
       this.switchTo('profile', this.profileData);
@@ -114,6 +115,7 @@
         this.showError(this.I18n.t('global.error.title'), data.message || this.I18n.t('order.error.message'));
         return;
       }
+      data.classname = data.status;
       data.status = this._localizeStatus(data.status);
 
       this.switchTo('order', { order: data });

--- a/app.js
+++ b/app.js
@@ -100,7 +100,9 @@
 
       // Got the profile data, populate interface
       this.profileData.created = this.localizeDate(this.profileData.created);
-      this.profileData.recentOrders = this._localizeStatuses(this.profileData.recentOrders);
+      this.profileData.recentOrders.forEach(function(order, key) {
+        this.profileData.recentOrders[key].status = this._localizeStatus(order.status);
+      }, this);
       this.switchTo('profile', this.profileData);
 
       this._appendTicketOrder();
@@ -112,6 +114,7 @@
         this.showError(this.I18n.t('global.error.title'), data.message || this.I18n.t('order.error.message'));
         return;
       }
+      data.status = this._localizeStatus(data.status);
 
       this.switchTo('order', { order: data });
     },
@@ -229,13 +232,9 @@
       this.$('.order').html(orderTemplate);
     },
 
-    _localizeStatuses: function(orders) {
-      orders.forEach(function(order, key) {
-        var localizedStatus = this.I18n.t('order.statuses.' + order.status);
-        orders[key].status = localizedStatus.indexOf('Missing translation') === 0 ? order.status : localizedStatus;
-      }, this);
-
-      return orders;
+    _localizeStatus: function(status) {
+      var localizedStatus = this.I18n.t('order.statuses.' + status);
+      return localizedStatus.indexOf('Missing translation') === 0 ? status : localizedStatus;
     }
 
   };

--- a/templates/order.hdbs
+++ b/templates/order.hdbs
@@ -4,7 +4,7 @@
 <p>{{{order.store}}}</p>
 
 <h5>{{t "order.status"}}</h5>
-<p><span class="badge badge-{{order.status}}">{{order.status}}</span></p>
+<p><span class="badge badge-{{order.classname}}">{{order.status}}</span></p>
 
 <h5>{{t "order.currency"}}</h5>
 <p>{{order.currency}}</p>

--- a/templates/profile.hdbs
+++ b/templates/profile.hdbs
@@ -19,7 +19,7 @@
       {{#recentOrders}}
       <tr class="_tooltip" data-title="{{titles}}" data-placement="top">
         <td><a href="{{admin_url}}" target="_blank">#{{id}}</td>
-        <td><span class="badge badge-{{status}}">{{status}}</a></td>
+        <td><span class="badge badge-{{classname}}">{{status}}</a></td>
       </tr>
       {{/recentOrders}}
     </tbody>


### PR DESCRIPTION
/cc @zendesk/mintegrations @injuhwang 

### Description

Previous localization fix applied in https://github.com/zendesk/magento_app/pull/42 only applied to the profile template.

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-644

### Risks
* [low] Order statuses may appear as missing translations.
